### PR TITLE
Add a new query interface for multiple values metrics func

### DIFF
--- a/metric.graphqls
+++ b/metric.graphqls
@@ -69,5 +69,10 @@ type Thermodynamic {
 extend type Query {
     getValues(metric: BatchMetricConditions!, duration: Duration!): IntValues
     getLinearIntValues(metric: MetricCondition!, duration: Duration!): IntValues
+    # Query the type of metrics including multiple values, and format them as multiple linears.
+    # The seq of these multiple lines base on the calculation func in OAL
+    # Such as, should us this to query the result of func percentile(50,75,90,95,99) in OAL,
+    # then five lines will be responsed, p50 is the first element of return value.
+    getMultiLinearsIntValues(metric: MetricCondition!, duration: Duration!): [IntValues!]!
     getThermodynamic(metric: MetricCondition!, duration: Duration!): Thermodynamic
 }


### PR DESCRIPTION
@aderm @Fine0830 I am following https://github.com/apache/skywalking/issues/4190#issuecomment-572863470

This new query will be suitable for query all p50-99 once. Also, reduce the backend payload and number of index.

A head-up, the Pxx like following will be removed from 7.0.0 release after this is provided in the main repo. The feature will keep unchanged, and query API and default OAL scripts will be changed. You could still use the old way by changing the OAL script manually back as same as 6.6.0.
```
service_p99 = from(Service.latency).p99(10);
service_p95 = from(Service.latency).p95(10);
service_p90 = from(Service.latency).p90(10);
service_p75 = from(Service.latency).p75(10);
service_p50 = from(Service.latency).p50(10);
```