### PR TITLE
New Metrics Query protocol 

### DIFF
--- a/aggregation.graphqls
+++ b/aggregation.graphqls
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Legacy metrics query protocol
-# Replyced by the metrics-v2 in the future
+# Replaced by the metrics-v2 in the future
 
 type TopNEntity {
     name: String!

--- a/aggregation.graphqls
+++ b/aggregation.graphqls
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Legacy metrics query protocol
+# Replyced by the metrics-v2 in the future
+
 type TopNEntity {
     name: String!
     id: ID!

--- a/common.graphqls
+++ b/common.graphqls
@@ -52,28 +52,6 @@ input Duration {
     step: Step!
 }
 
-input Entity {
-    # 1. scope=All, no name is required.
-    # 2. scope=Service, ServiceInstance and Endpoint, set neccessary serviceName/serviceInstanceName/endpointName
-    # 3. Scope=ServiceRelation, ServiceInstanceRelation and EndpointRelation
-    #    serviceName/serviceInstanceName/endpointName is/are the source(s)
-    #    destServiceName/destServiceInstanceName/destEndpointName is/are destination(s)
-    #    set necessary names of sources and destinations.
-    scope: Scope!
-    serviceName: String
-    # Normal service is the service having installed agent or metrics reported directly.
-    # Unnormal service is conjectural service, usually detected by the agent.
-    isNormal: Boolean
-    serviceInstanceName: String
-    endpointName: String
-    destServiceName: String
-    # Normal service is the service having installed agent or metrics reported directly.
-    # Unnormal service is conjectural service, usually detected by the agent.
-    destIsNormal: Boolean
-    destServiceInstanceName: String
-    destEndpointName: String
-}
-
 enum Step {
     DAY
     HOUR

--- a/common.graphqls
+++ b/common.graphqls
@@ -52,6 +52,28 @@ input Duration {
     step: Step!
 }
 
+input Entity {
+    # 1. scope=All, no name is required.
+    # 2. scope=Service, ServiceInstance and Endpoint, set neccessary serviceName/serviceInstanceName/endpointName
+    # 3. Scope=ServiceRelation, ServiceInstanceRelation and EndpointRelation
+    #    serviceName/serviceInstanceName/endpointName is/are the source(s)
+    #    destServiceName/destServiceInstanceName/destEndpointName is/are destination(s)
+    #    set necessary names of sources and destinations.
+    scope: Scope!
+    serviceName: String
+    # Normal service is the service having installed agent or metrics reported directly.
+    # Unnormal service is conjectural service, usually detected by the agent.
+    isNormal: Boolean
+    serviceInstanceName: String
+    endpointName: String
+    destServiceName: String
+    # Normal service is the service having installed agent or metrics reported directly.
+    # Unnormal service is conjectural service, usually detected by the agent.
+    destIsNormal: Boolean
+    destServiceInstanceName: String
+    destEndpointName: String
+}
+
 enum Step {
     DAY
     HOUR
@@ -86,6 +108,7 @@ enum Language {
 }
 
 enum Scope {
+    All
     Service
     ServiceInstance
     Endpoint

--- a/metadata.graphqls
+++ b/metadata.graphqls
@@ -14,15 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Query the cluster brief based on the given duration
-type ClusterBrief {
-    numOfService: Int!
-    numOfEndpoint: Int!
-    numOfDatabase: Int!
-    numOfCache: Int!
-    numOfMQ: Int!
-}
-
 type Service {
     id: ID!
     name: String!
@@ -67,8 +58,6 @@ type TimeInfo {
 }
 
 extend type Query {
-    getGlobalBrief(duration: Duration!): ClusterBrief
-
     # Normal service related metainfo 
     getAllServices(duration: Duration!): [Service!]!
     searchServices(duration: Duration!, keyword: String!): [Service!]!

--- a/metric.graphqls
+++ b/metric.graphqls
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Legacy metrics query protocol
+# Replyced by the metrics-v2 in the future
+
 input MetricCondition {
     # Metric name, which should be defined in OAL script
     # Such as:

--- a/metric.graphqls
+++ b/metric.graphqls
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Legacy metrics query protocol
-# Replyced by the metrics-v2 in the future
+# Replaced by the metrics-v2 in the future
 
 input MetricCondition {
     # Metric name, which should be defined in OAL script

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -88,7 +88,7 @@ type HeatMap {
     # Each element of values matches the time point of the query duration.
     # The element in the IntValues represents the value of the same index bucket
     values: [IntValues!]!
-    # Bucket describes the values represents.
+    # Bucket describes the ranges of #values represent.
     buckets: [Bucket!]!
 }
 

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -18,6 +18,23 @@
 # defined in the metric.graphql, top-n-records.graphqls, and aggregation.graphqls.
 # By leveraging the new ID rule(no register) in the v8, we could query metrics based on name(s) directly.
 
+type MetricsDefintion {
+    name: String!
+    valueType: MetricsType!
+}
+
+# Metrics type is a new concept since v8.
+enum MetricsType {
+    # Regular value type is suitable for readMetricsValue, readMetricsValues and sortMetrics
+    REGULAR_VALUE
+    # Metrics value includes multiple labels, is suitable for readLabeledMetricsValues
+    LABELED_VALUE
+    # Heatmap value suitable for readHeatMap
+    HEATMAP
+    # Top metrics is for readSampledRecords only. This value
+    SAMPLED_RECORD
+}
+
 input Entity {
     # 1. scope=All, no name is required.
     # 2. scope=Service, ServiceInstance and Endpoint, set neccessary serviceName/serviceInstanceName/endpointName
@@ -50,16 +67,6 @@ input MetricsCondition {
     entity: Entity
 }
 
-input BatchMetricsConditions {
-    # Metrics name, which should be defined in OAL script
-    # Such as:
-    # Endpoint_avg = from(Endpoint.latency).avg()
-    # Then, `Endpoint_avg`
-    name: String!
-    # Follow entity definition description.
-    ids: [Entity!]!
-}
-
 input TopNCondition {
     # Metrics name
     name: String!
@@ -69,60 +76,52 @@ input TopNCondition {
     order: Order!
 }
 
-type MetricsDefintion {
-    valueType: MetricsType
-}
-
-# Metrics type is a new concept since v8.
-enum MetricsType {
-    # Regular value type is suitable for getValuesByEntity, getLinearIntValuesByEntity
-    REGULAR_VALUE
-    HEATMAP
+type MetricsValues {
+    # Could be null if no label assigned in the query condition
+    lable: String
+    # Values of this label value.
+    values: IntValues
 }
 
 type HeatMap {
-    # Each element in nodes represents a point in Thermodynamic Diagram
-    # And the element includes three values:
-    # 1) Time Bucket based on query duration
-    # 2) Response time index.
-    #    Response time = [responseTimeStep * index, responseTimeStep * (index+1))
-    #    The last element: [Response Time * index, MAX)
-    # 3) The number of calls in this response time duration.
-    #
-    # Example:
-    # [ [0, 0, 10], [0, 1, 43], ...]
-    # These ^^^ two represent the left bottom element, and another element above it.
-    nodes: [[Int]!]!
-    axisYStep: Int!
+    # Each element of values matches the time point of the query duration.
+    # The element in the IntValues represents the value of the same index bucket
+    values: [IntValues!]!
+    # Bucket describes the values represents.
+    buckets: [Bucket!]!
 }
 
-type TopNMetrics {
+# Bucket represents the value range.
+type Bucket {
+    start: Int!
+    end: Int!
+}
+
+type TopNRecords {
+    # Literal string name for visualization
     name: String!
+    # ID repesents the owner of this entity.
     id: ID!
-    value: Long!
-}
-
-type TopNStatement {
-    statement: String
-    latency: Long!
-    # Have value, Only if the record has the trace id.
-    # Slow record
-    traceId: String
+    # Usually an integer as this is metrics.
+    value: String
+    # Have value, Only if the record has related trace id.
+    # UI should show this as an attached value.
+    refId: ID
 }
 
 extend type Query {
-    getValuesByEntity(metrics: BatchMetricsConditions!, duration: Duration!): IntValues
-    getLinearIntValuesByEntity(metrics: MetricsCondition!, duration: Duration!): IntValues
-    # Query the type of metrics including multiple values, and format them as multiple linears.
-    # The seq of these multiple lines base on the calculation func in OAL
-    # Such as, should us this to query the result of func percentile(50,75,90,95,99) in OAL,
-    # then five lines will be responsed, p50 is the first element of return value.
-    getMultipleLinearIntValuesByEntity(metrics: MetricsCondition!, linearIndex: [Int!]!, duration: Duration!): [IntValues!]!
-    getHeatmapByEntity(metrics: MetricsCondition!, duration: Duration!): HeatMap
-    # Get TopN metrics values from the given entity and parameters.
-    # The alternative query of get* in aggregation.graphqls
-    getTopN(metrics: TopNCondition!, order: Order!): [TopNMetrics!]!
-    # Get TopN statements from the given entity and parameters.
-    # The alternative query of get* in top-n-records.graphqls
-    getTopNStatements(metrics: TopNCondition!, order: Order!): [TopNStatement!]!
+    # Metrics definition metadata query. Respont the metrics type which determines the suitable query methods.
+    typeOfMetrics(names: String!): [MetricsDefintion!]!
+
+    # Read metrics single value in the duration of required metrics for
+    readMetricsValue(metrics: MetricsCondition!, duration: Duration!): Int!
+    readMetricsValues(metrics: MetricsCondition!, duration: Duration!): [MetricsValues!]!
+    sortMetrics(metrics: MetricsCondition!, duration: Duration!): [TopNRecords!]!
+    # Read value in the given time duration, usually as a linear.
+    # labels: the labels you need to query.
+    readLabeledMetricsValues(metrics: MetricsCondition!, labels: [String!]!, duration: Duration!): [MetricsValues!]!
+    # Heatmap is bucket based value statistic result.
+    readHeatMap(metrics: MetricsCondition!, duration: Duration!): HeatMap
+    # Read the sampled records
+    readSampledRecords(metrics: TopNCondition!, order: Order!): [TopNRecords!]!
 }

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Metrics v2 query protocol is an alternative metrics query(s) of original v1, defined in the metric.graphql and aggregation.graphqls.
+# By leveraging the new ID rule(no register) in the v8, we could query metrics based on name(s) directly.
+
+input MetricsCondition {
+    # Metrics name, which should be defined in OAL script
+    # Such as:
+    # Endpoint_avg = from(Endpoint.latency).avg()
+    # Then, `Endpoint_avg`
+    name: String!
+    # Follow entity definition description.
+    entity: Entity
+}
+
+input BatchMetricsConditions {
+    # Metrics name, which should be defined in OAL script
+    # Such as:
+    # Endpoint_avg = from(Endpoint.latency).avg()
+    # Then, `Endpoint_avg`
+    name: String!
+    # Follow entity definition description.
+    ids: [Entity!]!
+}
+
+input TopNCondition {
+    # Metrics name
+    name: String!
+    # Follow entity definition description.
+    entity: Entity
+    topN: Int!
+    order: Order!
+}
+
+type HeatMap {
+    # Each element in nodes represents a point in Thermodynamic Diagram
+    # And the element includes three values:
+    # 1) Time Bucket based on query duration
+    # 2) Response time index.
+    #    Response time = [responseTimeStep * index, responseTimeStep * (index+1))
+    #    The last element: [Response Time * index, MAX)
+    # 3) The number of calls in this response time duration.
+    #
+    # Example:
+    # [ [0, 0, 10], [0, 1, 43], ...]
+    # These ^^^ two represent the left bottom element, and another element above it.
+    nodes: [[Int]!]!
+    axisYStep: Int!
+}
+
+type TopN {
+    name: String!
+    id: ID!
+    value: Long!
+}
+
+extend type Query {
+    getValuesByEntity(metrics: BatchMetricsConditions!, duration: Duration!): IntValues
+    getLinearIntValuesByEntity(metrics: MetricsCondition!, duration: Duration!): IntValues
+    # Query the type of metrics including multiple values, and format them as multiple linears.
+    # The seq of these multiple lines base on the calculation func in OAL
+    # Such as, should us this to query the result of func percentile(50,75,90,95,99) in OAL,
+    # then five lines will be responsed, p50 is the first element of return value.
+    getMultipleLinearIntValuesByEntity(metrics: MetricsCondition!, linearIndex: [Int!]!, duration: Duration!): [IntValues!]!
+    getHeatmapByEntity(metrics: MetricsCondition!, duration: Duration!): HeatMap
+    # Get TopN from the given entity and parameters.
+    # The alternative query of get* in aggregation.graphqls
+    getTopN(metrics: TopNCondition!, order: Order!): [TopN!]!
+}

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -79,7 +79,7 @@ input TopNCondition {
 
 type MetricsValues {
     # Could be null if no label assigned in the query condition
-    lable: String
+    label: String
     # Values of this label value.
     values: IntValues
 }

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -111,7 +111,7 @@ type TopNRecords {
 }
 
 extend type Query {
-    # Metrics definition metadata query. Respont the metrics type which determines the suitable query methods.
+    # Metrics definition metadata query. Response the metrics type which determines the suitable query methods.
     typeOfMetrics(names: String!): [MetricsDefintion!]!
 
     # Read metrics single value in the duration of required metrics for

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -14,8 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Metrics v2 query protocol is an alternative metrics query(s) of original v1, defined in the metric.graphql and aggregation.graphqls.
+# Metrics v2 query protocol is an alternative metrics query(s) of original v1,
+# defined in the metric.graphql, top-n-records.graphqls, and aggregation.graphqls.
 # By leveraging the new ID rule(no register) in the v8, we could query metrics based on name(s) directly.
+
+input Entity {
+    # 1. scope=All, no name is required.
+    # 2. scope=Service, ServiceInstance and Endpoint, set neccessary serviceName/serviceInstanceName/endpointName
+    # 3. Scope=ServiceRelation, ServiceInstanceRelation and EndpointRelation
+    #    serviceName/serviceInstanceName/endpointName is/are the source(s)
+    #    destServiceName/destServiceInstanceName/destEndpointName is/are destination(s)
+    #    set necessary names of sources and destinations.
+    scope: Scope!
+    serviceName: String
+    # Normal service is the service having installed agent or metrics reported directly.
+    # Unnormal service is conjectural service, usually detected by the agent.
+    isNormal: Boolean
+    serviceInstanceName: String
+    endpointName: String
+    destServiceName: String
+    # Normal service is the service having installed agent or metrics reported directly.
+    # Unnormal service is conjectural service, usually detected by the agent.
+    destIsNormal: Boolean
+    destServiceInstanceName: String
+    destEndpointName: String
+}
 
 input MetricsCondition {
     # Metrics name, which should be defined in OAL script
@@ -46,6 +69,17 @@ input TopNCondition {
     order: Order!
 }
 
+type MetricsDefintion {
+    valueType: MetricsType
+}
+
+# Metrics type is a new concept since v8.
+enum MetricsType {
+    # Regular value type is suitable for getValuesByEntity, getLinearIntValuesByEntity
+    REGULAR_VALUE
+    HEATMAP
+}
+
 type HeatMap {
     # Each element in nodes represents a point in Thermodynamic Diagram
     # And the element includes three values:
@@ -62,10 +96,18 @@ type HeatMap {
     axisYStep: Int!
 }
 
-type TopN {
+type TopNMetrics {
     name: String!
     id: ID!
     value: Long!
+}
+
+type TopNStatement {
+    statement: String
+    latency: Long!
+    # Have value, Only if the record has the trace id.
+    # Slow record
+    traceId: String
 }
 
 extend type Query {
@@ -77,7 +119,10 @@ extend type Query {
     # then five lines will be responsed, p50 is the first element of return value.
     getMultipleLinearIntValuesByEntity(metrics: MetricsCondition!, linearIndex: [Int!]!, duration: Duration!): [IntValues!]!
     getHeatmapByEntity(metrics: MetricsCondition!, duration: Duration!): HeatMap
-    # Get TopN from the given entity and parameters.
+    # Get TopN metrics values from the given entity and parameters.
     # The alternative query of get* in aggregation.graphqls
-    getTopN(metrics: TopNCondition!, order: Order!): [TopN!]!
+    getTopN(metrics: TopNCondition!, order: Order!): [TopNMetrics!]!
+    # Get TopN statements from the given entity and parameters.
+    # The alternative query of get* in top-n-records.graphqls
+    getTopNStatements(metrics: TopNCondition!, order: Order!): [TopNStatement!]!
 }

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -28,6 +28,7 @@ enum MetricsType {
     # Regular value type is suitable for readMetricsValue, readMetricsValues and sortMetrics
     REGULAR_VALUE
     # Metrics value includes multiple labels, is suitable for readLabeledMetricsValues
+    # Label should be assigned before the query happens, such as at the setting stage
     LABELED_VALUE
     # Heatmap value suitable for readHeatMap
     HEATMAP

--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -124,5 +124,5 @@ extend type Query {
     # Heatmap is bucket based value statistic result.
     readHeatMap(metrics: MetricsCondition!, duration: Duration!): HeatMap
     # Read the sampled records
-    readSampledRecords(metrics: TopNCondition!, order: Order!): [TopNRecords!]!
+    readSampledRecords(metrics: TopNCondition!, order: Order!, duration: Duration!): [TopNRecords!]!
 }

--- a/top-n-records.graphqls
+++ b/top-n-records.graphqls
@@ -19,7 +19,7 @@
 # the top N record query is just do order and get the list.
 
 # Legacy metrics query protocol
-# Replyced by the metrics-v2 in the future
+# Replaced by the metrics-v2 in the future
 
 # Top N query is based on latency order by given service and metric name.
 input TopNRecordsCondition {

--- a/top-n-records.graphqls
+++ b/top-n-records.graphqls
@@ -18,6 +18,9 @@
 # Both of query results are top N, but aggregation topN query needs to do aggregation at query stage,
 # the top N record query is just do order and get the list.
 
+# Legacy metrics query protocol
+# Replyced by the metrics-v2 in the future
+
 # Top N query is based on latency order by given service and metric name.
 input TopNRecordsCondition {
     serviceId: ID!


### PR DESCRIPTION
This protocol provides the capability, client side could use name rather than ID to query metrics. This is much easier and suitable for the new metrics system.