### PR TITLE
Update metrics-v2.graphqls

### DIFF
--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -128,7 +128,7 @@ extend type Query {
     typeOfMetrics(name: String!): MetricsType!
 
     # Read metrics single value in the duration of required metrics
-    readMetricsValue(condition: MetricsCondition!, duration: Duration!): Int!
+    readMetricsValue(condition: MetricsCondition!, duration: Duration!): Long!
     # Read time-series values in the duration of required metrics
     readMetricsValues(condition: MetricsCondition!, duration: Duration!): MetricsValues!
     # Read entity list of required metrics and parent entity type.


### PR DESCRIPTION
Make readMetricsValue return Long value. That intends to query a long value which represents milliseconds from the Unix time epoch. 

Related to https://github.com/apache/skywalking/issues/5175