### PR TITLE
Rollback to re-enable normal concept.

### DIFF
--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -18,10 +18,6 @@
 # defined in the metric.graphql, top-n-records.graphqls, and aggregation.graphqls.
 # By leveraging the new ID rule(no register) in the v8, we could query metrics based on name(s) directly.
 
-# Metrics v2.1 is introduced since SkyWalking v9 core.
-# Change logs:
-# - The normal and destNormal tags have been deprecated.
-
 # Metrics type is a new concept since v8.
 enum MetricsType {
     # Can't find the metrics type definition.
@@ -46,16 +42,17 @@ input Entity {
     #    set necessary names of sources and destinations.
     scope: Scope!
     serviceName: String
+    # Normal service is the service having installed agent or metrics reported directly.
+    # Unnormal service is conjectural service, usually detected by the agent.
+    normal: Boolean
     serviceInstanceName: String
     endpointName: String
     destServiceName: String
+    # Normal service is the service having installed agent or metrics reported directly.
+    # Unnormal service is conjectural service, usually detected by the agent.
+    destNormal: Boolean
     destServiceInstanceName: String
     destEndpointName: String
-
-    # Deprecated since 9.0.0. Don't need to use this anymore
-    normal: Boolean
-    # Deprecated since 9.0.0. Don't need to use this anymore
-    destNormal: Boolean
 }
 
 input MetricsCondition {
@@ -73,15 +70,15 @@ input TopNCondition {
     name: String!
     # Could be null if query the global top N.
     parentService: String
+    # Normal service is the service having installed agent or metrics reported directly.
+    # Unnormal service is conjectural service, usually detected by the agent.
+    normal: Boolean
     # Indicate the metrics entity scope.
     # This is required in sortMetrics query.
     # Only accept scope = Service/ServiceInstance/Endpoint, ignore others due to those are pointless.
     scope: Scope
     topN: Int!
     order: Order!
-
-    # Deprecated since 9.0.0. Don't need to use this anymore
-    normal: Boolean
 }
 
 # Define the metrics provided in the OAP server.

--- a/topology.graphqls
+++ b/topology.graphqls
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Topology v1.1 is introduced from SkyWalking v9 core.
-# Change logs
-# - Deprecated `isReal`, due to in v9, service is about real or not real, it has native layer attribute to determine its type and scope.
-# - Deprecated `type` in instance topology and endpoint dependency, because by their latest definitions, they are subsets of services, no point has specific type.
-# - All deprecated fields are kept for keeping back-forward compatibility. `isReal=true` and `type=(empty string)` are default values only.
-
 # The overview topology of the whole application cluster or services,
 type Topology {
     nodes: [Node!]!
@@ -48,8 +42,7 @@ type Node {
     # 1. The service provider/middleware tech, such as: Tomcat, SpringMVC
     # 2. Conjectural Service, e.g. MySQL, Redis, Kafka
     type: String
-
-    # Deprecated since 9.0.0. Don't need to use this anymore
+    # It is a conjecture node or real node, to represent a service or endpoint.
     isReal: Boolean!
 }
 
@@ -63,11 +56,12 @@ type ServiceInstanceNode {
     serviceId: ID!
     # The literal name of the #serviceId.
     serviceName: String!
-
-    # Deprecated since 9.0.0. Instance is an executable unit of service, it doesn't have its own type.
+    # The type name may be
+    # 1. The service provider/middleware tech, such as: Tomcat, SpringMVC
+    # 2. Conjectural Service, e.g. MySQL, Redis, Kafka
     type: String
-    # Deprecated since 9.0.0. Don't need to use this anymore
-    isReal: Boolean
+    # It is a conjecture node or real node, to represent an instance.
+    isReal: Boolean!
 }
 
 # Node in EndpointTopology
@@ -80,11 +74,12 @@ type EndpointNode {
     serviceId: ID!
     # The literal name of the #serviceId.
     serviceName: String!
-
-    # Deprecated since 9.0.0. The endpoint is the minimal functional unit., it doesn't have its own type.
+    # The type name may be
+    # 1. The service provider/middleware tech, such as: Tomcat, SpringMVC
+    # 2. Conjectural Service, e.g. MySQL, Redis, Kafka
     type: String
-    # Deprecated since 9.0.0. Don't need to use this anymore
-    isReal: Boolean
+    # It is a conjuecture node or real node, to represent an instance.
+    isReal: Boolean!
 }
 
 # The Call represents a directed distributed call,


### PR DESCRIPTION
Re-enable the `normal` concept, as topology will require this to determine whether node could be clicked or not, to open the metrics panels.