### PR TITLE
Add query trace tag autocomplete

### DIFF
--- a/trace.graphqls
+++ b/trace.graphqls
@@ -119,4 +119,6 @@ type LogEntity {
 extend type Query {
     queryBasicTraces(condition: TraceQueryCondition): TraceBrief
     queryTrace(traceId: ID!): Trace
+    queryTraceTagAutocompleteKeys:[String!]
+    queryTraceTagAutocompleteValues(tagKey: String!):[String!]
 }


### PR DESCRIPTION
`queryTraceTagAutocompleteKeys` return  the white list `searchableTracesTags` directly.
`queryTraceTagAutocompleteValues` return the key's value from the storage.