### PR TITLE
Remove total in query trace and log list.

### DIFF
--- a/common.graphqls
+++ b/common.graphqls
@@ -76,8 +76,8 @@ input Pagination {
     # pageNum starts in 1, the default is 1.
     pageNum: Int
     pageSize: Int!
-    # default false
-    needTotal: Boolean
+    # total is not provided since 9.1.0
+    # The client side determines the existing of the next page, which should be TRUE when `size of response list` == `pageSize'
 }
 
 enum Language {

--- a/log.graphqls
+++ b/log.graphqls
@@ -17,7 +17,6 @@
 # The list of logs
 type Logs {
     logs: [Log!]!
-    total: Int!
 }
 
 # Log info

--- a/trace.graphqls
+++ b/trace.graphqls
@@ -17,7 +17,6 @@
 # The list of traces
 type TraceBrief {
     traces: [BasicTrace!]!
-    total: Int!
 }
 
 # Trace basic info


### PR DESCRIPTION
FYI @apache/skywalking-committers This would be a breaking change. We don't have time to do this in the 9.0.0 release, sorry to notify this so late.

@mrproliu We need this landed on CLI for main repo changes

@Fine0830 UI should follow this and remove the total pages/numbers from logs and traces query