### PR TITLE
Add TraceSource for trace query

### DIFF
--- a/trace.graphqls
+++ b/trace.graphqls
@@ -49,6 +49,7 @@ input TraceQueryCondition {
     paging: Pagination!
     # [Optional] SkyWalking supports traces collected by SkyWalking's native agents and Zipkin's native agents
     # This prioritized source determines one of them has high priority in the trace list.
+    # The default value is TraceSource.SKYWALKING
     prioritizedSource: TraceSource
 }
 

--- a/trace.graphqls
+++ b/trace.graphqls
@@ -47,6 +47,9 @@ input TraceQueryCondition {
     # Map to the tags included in the traces
     tags: [SpanTag!]
     paging: Pagination!
+    # [Optional] SkyWalking supports traces collected by SkyWalking's native agents and Zipkin's native agents
+    # This prioritized source determines one of them has high priority in the trace list.
+    prioritizedSource: TraceSource
 }
 
 input SpanTag {
@@ -63,6 +66,12 @@ enum TraceState {
 enum QueryOrder {
     BY_START_TIME
     BY_DURATION
+}
+
+# The datasource and datasource of collected traces/spans
+enum TraceSource {
+    SKYWALKING
+    ZIPKIN
 }
 
 # The trace represents a distributed trace, includes all segments and spans.


### PR DESCRIPTION
@wankai123 @Fine0830 Following https://github.com/apache/skywalking/issues/8932, we could support Zipkin and SkyWalking traces at the same time, and the trace query component supports paging, so when UI does the query, OAP should know which traces should be listed in the page before the other format. The other trace should only be queried when the prioritized one doesn't has enough values(size of current page is less than the page size)

So, I added this parameter as optional. `TraceSource.SKYWALKING` is the default value for GraphQL query, and `TraceSource.ZIPKIN` should be the default for Zipkin restful Query APIs.(Zipkin Lens UI)

@Fine0830 We should support configurations in the trace query widget on the UI to set the default value because I prefer to set `TraceSource.SKYWALKING` in general service and FAAS dashboards, but use `TraceSource.ZIPKIN` in the Mesh service page(and activating Zipkin tracer in the showcase, FYI @kezhenxu94 @mrproliu)