### PR TITLE
Add new record query protocol.

### DIFF
--- a/metrics-v2.graphqls
+++ b/metrics-v2.graphqls
@@ -153,6 +153,7 @@ extend type Query {
     readLabeledMetricsValues(condition: MetricsCondition!, labels: [String!]!, duration: Duration!): [MetricsValues!]!
     # Heatmap is bucket based value statistic result.
     readHeatMap(condition: MetricsCondition!, duration: Duration!): HeatMap
+    # Deprecated since 9.3.0, replaced by readRecords defined in record.graphqls
     # Read the sampled records
     # TopNCondition#scope is not required.
     readSampledRecords(condition: TopNCondition!, duration: Duration!): [SelectedRecord!]!

--- a/record.graphqls
+++ b/record.graphqls
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Since 9.3.0
+# Record is a general and abstract type for collected raw data.
+# In the observability, traces and logs have specific and well-defined meanings, and the general records represent other
+# collected records. Such as sampled slow SQL statement, HTTP request raw data(request/response header/body)
+extend type Query {
+    # Query collected records with given metric name and parent entity conditions, and return in the requested order.
+    readRecords(condition: RecordCondition!, duration: Duration!): [Record!]!
+}
+
+input RecordCondition {
+    # Metrics name
+    # The scope of this metric is required to match the scope of the parent entity.
+    name: String!
+    # Follow entity definition description.
+    # The owner of the sampled records
+    parentEntity: Entity!
+    topN: Int!
+    order: Order!
+}
+
+type Record {
+    # Literal string name for visualization
+    name: String!
+    # ID of this record
+    id: ID!
+    # Usually an integer value as this is a metric to measure this entity ID.
+    value: String
+    # Have value, Only if the record has related trace id.
+    # UI should show this as an attached value.
+    refId: ID
+}


### PR DESCRIPTION
```
# Since 9.3.0
# Record is a general and abstract type for collected raw data.
# In the observability, traces and logs have specific and well-defined meanings, and the general records represent other
# collected records. Such as sampled slow SQL statement, HTTP request raw data(request/response header/body)
extend type Query {
    # Query collected records with given metric name and parent entity conditions, and return in the requested order.
    readRecords(condition: RecordCondition!, duration: Duration!): [Record!]!
}
```

A new query protocol is being added, to replace the `readSampledRecords`. This would be a compatible upgrade to support more use cases for sampled records(such as in instance level) and incoming HTTP header/body collecting(through ebpf agent).

In ebpf case, we would be able to sample HTTP request/response according to latency threshold, even 100% sampling. And link those records with trace ID/span ID decoded from the sw8(skywalking)/b3(zipkin) header. Then we could have this diagnose workflow, `slow HTTP request` -> `TRACE view` -> `RPC span with attached event`. The event includes the HTTP request/response in step <1>, as well as statistics of network events(ref https://github.com/apache/skywalking-data-collect-protocol/pull/77)