### PR TITLE
Remove the must configuration on sampling field

### DIFF
--- a/ebpf-profiling.graphqls
+++ b/ebpf-profiling.graphqls
@@ -68,7 +68,7 @@ input EBPFProfilingNetworkTaskRequest {
 
     # The rule list for network profiling.
     # Set various rules for different HTTP URIs if necessary.
-    samplings: [EBPFNetworkSamplingRule!]!
+    samplings: [EBPFNetworkSamplingRule!]
 }
 
 # eBPF Profiling task creation result


### PR DESCRIPTION
For GraphQL compatibility on the different versions of the backend and UI, removing the sampling must not null config