### PR TITLE
optional layer param for listServices endpoint

### DIFF
--- a/metadata-v2.graphqls
+++ b/metadata-v2.graphqls
@@ -116,7 +116,7 @@ extend type Query {
     listLayers: [String!]!
     
     # Read the service list according to layer.
-    listServices(layer: String!): [Service!]!
+    listServices(layer: String): [Service!]!
     # Find service according to given ID. Return null if not existing.
     getService(serviceId: String!): Service
     # Search and find service according to given name. Return null if not existing.


### PR DESCRIPTION
The implementation behind `listServices` shows that the `layer` param is actually optional (e.g. [code](https://github.com/apache/skywalking/blob/eebea38789df0a71bd8413293d41135cab17c00c/oap-server/server-storage-plugin/storage-elasticsearch-plugin/src/main/java/org/apache/skywalking/oap/server/storage/plugin/elasticsearch/query/MetadataQueryEsDAO.java#L93)).

Additionally, to get all the services you have to send `layer=""`. I think it would make more sense to just not send `layer`.