### PR TITLE
Support cross-thread trace profiling

### DIFF
--- a/profile.graphqls
+++ b/profile.graphqls
@@ -116,6 +116,8 @@ type ProfileAnalyzation {
 type ProfiledSpan {
     spanId: Int!
     parentSpanId: Int!
+    segmentId: ID!
+    refs: [Ref!]!
     serviceCode: String!
     serviceInstanceName: ID!
     startTime: Long!
@@ -134,6 +136,11 @@ type ProfiledSpan {
 }
 
 type ProfiledSegment {
+    spans: [ProfiledSpan!]!
+}
+
+type ProfiledSegments {
+    segments: [ID!]!
     spans: [ProfiledSpan!]!
 }
 
@@ -156,6 +163,10 @@ extend type Query {
     getProfileTaskSegmentList(taskID: String): [BasicTrace!]!
     # query profiled segment
     getProfiledSegment(segmentId: String): ProfiledSegment
+    # query combined segments by ref
+    getProfiledSegments(segmentIds: [String!]!): [ProfiledSegments!]!
     # analyze profiled segment, start and end time use timestamp(millisecond)
     getProfileAnalyze(segmentId: String!, timeRanges: [ProfileAnalyzeTimeRange!]!): ProfileAnalyzation!
+    # analyze multiple profiled segments, start and end time use timestamp(millisecond)
+    getSegmentsProfileAnalyze(segmentIds: [String!]!, timeRanges: [ProfileAnalyzeTimeRange!]!): ProfileAnalyzation!
 }

--- a/profile.graphqls
+++ b/profile.graphqls
@@ -133,7 +133,7 @@ type ProfiledSpan {
     layer: String
     tags: [KeyValue!]!
     logs: [LogEntity!]!
-    # is the span belongs the segments been profiled
+    # Status represents profiling data that covers the duration of the span.
     profiled: Boolean!
 }
 

--- a/profile.graphqls
+++ b/profile.graphqls
@@ -146,7 +146,7 @@ input ProfileAnalyzeTimeRange {
     end: Long!
 }
 
-type ProfiledSegments {
+type ProfiledTraceSegments {
     traceId: String!
     instanceId: ID!
     instanceName: String!
@@ -154,6 +154,11 @@ type ProfiledSegments {
     duration: Int!
     start: String!
     spans: [ProfiledSpan!]!
+}
+
+input SegmentProfileAnalyzeQuery {
+    segmentId: String!
+    timeRange: ProfileAnalyzeTimeRange!
 }
 
 extend type Mutation {
@@ -167,7 +172,7 @@ extend type Query {
     # query all task logs
     getProfileTaskLogs(taskID: String): [ProfileTaskLog!]!
     # query all task profiled segment list
-    getProfileTaskSegments(taskID: ID!): [ProfiledSegments!]!
+    getProfileTaskSegments(taskID: ID!): [ProfiledTraceSegments!]!
     # analyze multiple profiled segments, start and end time use timestamp(millisecond)
-    getSegmentsProfileAnalyze(segmentIds: [String!]!, timeRanges: [ProfileAnalyzeTimeRange!]!): ProfileAnalyzation!
+    getSegmentsProfileAnalyze(queries: [SegmentProfileAnalyzeQuery!]!): ProfileAnalyzation!
 }

--- a/profile.graphqls
+++ b/profile.graphqls
@@ -133,20 +133,27 @@ type ProfiledSpan {
     layer: String
     tags: [KeyValue!]!
     logs: [LogEntity!]!
+    # is the span belongs the segments been profiled
+    profiled: Boolean!
 }
 
 type ProfiledSegment {
     spans: [ProfiledSpan!]!
 }
 
-type ProfiledSegments {
-    segments: [ID!]!
-    spans: [ProfiledSpan!]!
-}
-
 input ProfileAnalyzeTimeRange {
     start: Long!
     end: Long!
+}
+
+type ProfiledSegments {
+    traceId: String!
+    instanceId: ID!
+    instanceName: String!
+    endpointNames: [String!]!
+    duration: Int!
+    start: String!
+    spans: [ProfiledSpan!]!
 }
 
 extend type Mutation {
@@ -160,13 +167,7 @@ extend type Query {
     # query all task logs
     getProfileTaskLogs(taskID: String): [ProfileTaskLog!]!
     # query all task profiled segment list
-    getProfileTaskSegmentList(taskID: String): [BasicTrace!]!
-    # query profiled segment
-    getProfiledSegment(segmentId: String): ProfiledSegment
-    # query combined segments by ref
-    getProfiledSegments(segmentIds: [String!]!): [ProfiledSegments!]!
-    # analyze profiled segment, start and end time use timestamp(millisecond)
-    getProfileAnalyze(segmentId: String!, timeRanges: [ProfileAnalyzeTimeRange!]!): ProfileAnalyzation!
+    getProfileTaskSegments(taskID: ID!): [ProfiledSegments!]!
     # analyze multiple profiled segments, start and end time use timestamp(millisecond)
     getSegmentsProfileAnalyze(segmentIds: [String!]!, timeRanges: [ProfileAnalyzeTimeRange!]!): ProfileAnalyzation!
 }


### PR DESCRIPTION
Following https://github.com/apache/skywalking/issues/10373
We need to let GraphQL support query/analysis with multiple segments.