### PR TITLE
SkyWalking Metrics Query Expression(MQE) protocol

### DIFF
--- a/metrics-expression.graphqls
+++ b/metrics-expression.graphqls
@@ -32,15 +32,6 @@ enum ExpressionResultType {
     RECORD_LIST
 }
 
-type MQEValues {
-    labels: [String!]!
-    # 1. When the type == SINGLE_VALUE, values only have one value.
-    # 2. When the type == TIME_SERIES_VALUES, values would match the given elements in the duration range.
-    # 3. When the type == SORTED_LIST, values could be results of `sort(metric)`
-    # 4. When the type == RECORD_LIST, values could be sampled records
-    values: [MQEValue!]!
-}
-
 type MQEValue {
     id: ID!
     value: String!
@@ -50,8 +41,19 @@ type MQEValue {
     traceID: ID
 }
 
+type MQEValues {
+    labels: [String!]!
+    # 1. When the type == SINGLE_VALUE, values only have one value.
+    # 2. When the type == TIME_SERIES_VALUES, values would match the given elements in the duration range.
+    # 3. When the type == SORTED_LIST, values could be results of `sort(metric)`
+    # 4. When the type == RECORD_LIST, values could be sampled records
+    values: [MQEValue!]!
+}
+
 type ExpressionResult {
     type: ExpressionResultType!
+    # When the type == TIME_SERIES_VALUES, the results would be a collection of MQEValues.
+    # In other legal type cases, only one MQEValues is expected in the array.
     results: [MQEValues!]!
 }
 

--- a/metrics-expression.graphqls
+++ b/metrics-expression.graphqls
@@ -25,18 +25,19 @@ enum ExpressionResultType {
     # A collection of time-series values.
     # The value could have labels or not.
     TIME_SERIES_VALUES
-    # A collection of aggregated or sampled values.
-    # When the original metric type is sampled records or through metric sort function
-    LIST
+    # A collection of aggregated values through metric sort function
+    SORTED_LIST
+    # A collection of sampled records.
+    # When the original metric type is sampled records
+    RECORD_LIST
 }
 
 type MQEValues {
     labels: [String!]!
     # 1. When the type == SINGLE_VALUE, values only have one value.
     # 2. When the type == TIME_SERIES_VALUES, values would match the given elements in the duration range.
-    # 3. When the type == LIST, values could be
-    #    3.1 sampled records
-    #    3.2 results of `sort(metric)`
+    # 3. When the type == SORTED_LIST, values could be results of `sort(metric)`
+    # 4. When the type == RECORD_LIST, values could be sampled records
     values: [MQEValue!]!
 }
 
@@ -51,7 +52,7 @@ type MQEValue {
 
 type ExpressionResult {
     type: ExpressionResultType!
-    results: MQEValues!
+    results: [MQEValues!]!
 }
 
 

--- a/metrics-expression.graphqls
+++ b/metrics-expression.graphqls
@@ -26,7 +26,7 @@ enum ExpressionResultType {
     # The value could have labels or not.
     TIME_SERIES_VALUES
     # A collection of aggregated or sampled values.
-    # When the original metric type is sampled records or through metric sorting
+    # When the original metric type is sampled records or through metric sort function
     LIST
 }
 
@@ -46,7 +46,7 @@ type MQEValue {
     isEmptyValue: Boolean!
     # Sampled record could associate with a trace.
     # This would be a trace ID only.
-    attachmentID: ID!
+    traceID: ID
 }
 
 type ExpressionResult {

--- a/metrics-expression.graphqls
+++ b/metrics-expression.graphqls
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SkyWalking Metrics Query Expression(MQE) is an extension query mechanism.
+# MQE allows users to do simple query-stage calculation like well known PromQL.
+
+enum ExpressionResultType {
+    # Can't resolve the type of the given expression.
+    UNKNOWN
+    # A single value
+    SINGLE_VALUE
+    # A collection of time-series values.
+    # The value could have labels or not.
+    TIME_SERIES_VALUES
+    # A collection of aggregated or sampled values.
+    # When the original metric type is sampled records or through metric sorting
+    LIST
+}
+
+type MQEValues {
+    labels: [String!]!
+    # 1. When the type == SINGLE_VALUE, values only have one value.
+    # 2. When the type == TIME_SERIES_VALUES, values would match the given elements in the duration range.
+    # 3. When the type == LIST, values could be
+    #    3.1 sampled records
+    #    3.2 results of `sort(metric)`
+    values: [MQEValue!]!
+}
+
+type MQEValue {
+    id: ID!
+    value: String!
+    isEmptyValue: Boolean!
+    # Sampled record could associate with a trace.
+    # This would be a trace ID only.
+    attachmentID: ID!
+}
+
+type ExpressionResult {
+    type: ExpressionResultType!
+    results: MQEValues!
+}
+
+
+extend type Query {
+    # The return type of the given expression
+    returnTypeOfMQE(expression: String!): ExpressionResultType!
+    execExpression(expression: String!, entity: Entity!, duration: Duration!): ExpressionResult!
+}

--- a/metrics-expression.graphqls
+++ b/metrics-expression.graphqls
@@ -42,12 +42,20 @@ type MQEValue {
 }
 
 type MQEValues {
-    labels: [String!]!
+    # The metadata description of this value series.
+    metric: Metadata!
     # 1. When the type == SINGLE_VALUE, values only have one value.
     # 2. When the type == TIME_SERIES_VALUES, values would match the given elements in the duration range.
     # 3. When the type == SORTED_LIST, values could be results of `sort(metric)`
     # 4. When the type == RECORD_LIST, values could be sampled records
     values: [MQEValue!]!
+}
+
+type Metadata {
+    # The metric logical name
+    name: String!
+    # Key-value pairs to describe the metric
+    labels: [KeyValue!]!
 }
 
 type ExpressionResult {


### PR DESCRIPTION
According to the experiences we learned when implementing the PromQL support, I think we should consider our own expression system in the query stage to reduce the dependencies on the UI side 

FYI @apache/skywalking-committers 

## Metrics Query Expression(MQE)
I would leave the details of MQE grammar to @wankai123, as he is much more familiar with PromQL expression.
At least, we could support these kinds of expressions

- round(service_sla / 100, 1) // keep one digital for a double
- service_success_count / service_total_count // calculate with multiple metric
- avg(service_cpm) // a single value
- sort(service_sla, ASC, 10) // get lowest N services by the value of success rate
- sampled_slow_trace_record / 100 // Read sampled record and the value_column(`latency`) should divide 100

The expression includes metrics with different types, that would cause `UNKNOWN` value.

