### PR TITLE
enhance the alarm kernel with recovered status notification capability #13492

### DIFF
--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -28,7 +28,7 @@ type AlarmSnapshot {
 
 type AlarmMessage {
     startTime: Long!
-    recoveryTime: Long!
+    recoveryTime: Long
     scope: Scope
     id: ID!
     # The entity name of the alarm triggered.

--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -28,6 +28,7 @@ type AlarmSnapshot {
 
 type AlarmMessage {
     startTime: Long!
+    recoveryTime: Long!
     scope: Scope
     id: ID!
     # The entity name of the alarm triggered.


### PR DESCRIPTION
Add Query API for [#13492](https://github.com/apache/skywalking/issues/13492)

Enhance the alarm kernel with recovered status notification capability 
Add `recoveryTime` field to `AlarmMessage`