### PR TITLE
alarm: add `layers` filter on getAlarm and `layers` on AlarmMessage

### DIFF
--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -33,11 +33,10 @@ type AlarmMessage {
     id: ID!
     # The entity name of the alarm triggered.
     name: String!
-    # The layers the alarmed entity (service / instance / endpoint / process and their
+    # The layers of the alarmed entity (service / instance / endpoint / process and their
     # relations) belongs to at the time the alarm was raised. A service can be observed
     # under multiple layers simultaneously (e.g., GENERAL + MESH); each entry here
-    # corresponds to one layer the underlying entity served at alarm time.
-    # See https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java
+    # corresponds to one layer of the underlying entity served at alarm time.
     # for the list of layer names.
     layers: [String!]!
     message: String!

--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -33,6 +33,13 @@ type AlarmMessage {
     id: ID!
     # The entity name of the alarm triggered.
     name: String!
+    # The layers the alarmed entity (service / instance / endpoint / process and their
+    # relations) belongs to at the time the alarm was raised. A service can be observed
+    # under multiple layers simultaneously (e.g., GENERAL + MESH); each entry here
+    # corresponds to one layer the underlying entity served at alarm time.
+    # See https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java
+    # for the list of layer names.
+    layers: [String!]!
     message: String!
     events: [Event!]!
     tags: [KeyValue!]!
@@ -50,7 +57,11 @@ input AlarmTag {
 }
 
 extend type Query {
-    getAlarm(duration: Duration!, scope: Scope, keyword: String, paging: Pagination!, tags: [AlarmTag]): Alarms
+    # `layers` (optional) filters to alarms whose underlying entity belongs to ANY of the
+    # given layers (set union, OR semantics). Empty or omitted = no layer filter applied.
+    # Layer values are the free-form strings used elsewhere in the protocol; see
+    # `Service.layers` and metadata-v2.graphqls for the canonical layer list.
+    getAlarm(duration: Duration!, scope: Scope, layers: [String!], keyword: String, paging: Pagination!, tags: [AlarmTag]): Alarms
     # Read the list of searchable keys
     queryAlarmTagAutocompleteKeys(duration: Duration!):[String!]
     # Search the available value options of the given key.


### PR DESCRIPTION
## Summary

Adds layer awareness to the alarm query surface.

- New required field `AlarmMessage.layers: [String!]!` — the layer(s) the alarmed entity belonged to at the time the alarm was raised. A service can be observed under multiple layers simultaneously (e.g., `GENERAL` + `MESH`); each entry records one layer.
- New optional argument `getAlarm(... , layers: [String!], ...)` — filter alarms whose underlying entity belongs to **any** of the given layers (set union, OR semantics). Empty / omitted = no layer filter applied (current behavior).

Both fields use `String` to match the rest of the protocol (`Service.layers`, `listServices(layer: String)`) — the layer value space is free-form, with the canonical list documented at https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java.

## Backward compatibility

- `AlarmMessage.layers` is non-null on the wire. For pre-upgrade alarm records (no layer recorded on disk), the OAP backend will return an empty list — clients that don't request the field stay unaffected.
- `getAlarm`'s new argument is optional. Existing queries continue to work.

## Companion PRs

The OAP backend implementation (alarm record model + persistence + storage DAOs for BanyanDB / ES / JDBC) will land in a separate apache/skywalking PR that pins this submodule SHA once this merges. The resolver wiring (`AlarmQuery#getAlarm`) is part of the same OAP PR.

## Test plan
- [ ] OAP backend PR builds against this commit
- [ ] e2e: `getAlarm(layers: ["general"])` returns the matching alarm records

🤖 Generated with [Claude Code](https://claude.com/claude-code)