### PR TITLE
Revert PR #155 (alarm layers) — superseded by upcoming alarm query API

### DIFF
--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -33,12 +33,6 @@ type AlarmMessage {
     id: ID!
     # The entity name of the alarm triggered.
     name: String!
-    # The layers of the alarmed entity (service / instance / endpoint / process and their
-    # relations) belongs to at the time the alarm was raised. A service can be observed
-    # under multiple layers simultaneously (e.g., GENERAL + MESH); each entry here
-    # corresponds to one layer of the underlying entity served at alarm time.
-    # for the list of layer names.
-    layers: [String!]!
     message: String!
     events: [Event!]!
     tags: [KeyValue!]!
@@ -56,11 +50,7 @@ input AlarmTag {
 }
 
 extend type Query {
-    # `layers` (optional) filters to alarms whose underlying entity belongs to ANY of the
-    # given layers (set union, OR semantics). Empty or omitted = no layer filter applied.
-    # Layer values are the free-form strings used elsewhere in the protocol; see
-    # `Service.layers` and metadata-v2.graphqls for the canonical layer list.
-    getAlarm(duration: Duration!, scope: Scope, layers: [String!], keyword: String, paging: Pagination!, tags: [AlarmTag]): Alarms
+    getAlarm(duration: Duration!, scope: Scope, keyword: String, paging: Pagination!, tags: [AlarmTag]): Alarms
     # Read the list of searchable keys
     queryAlarmTagAutocompleteKeys(duration: Duration!):[String!]
     # Search the available value options of the given key.


### PR DESCRIPTION
## Summary

Reverts #155 in preparation for a more comprehensive alarm query API that bundles the layer field together with entity-id / rule-name filters under a single new `queryAlarms(condition: AlarmQueryCondition!)` query.

#155 added a `layers` argument to the existing `getAlarm` and a `layers: [String!]!` field to `AlarmMessage`. The new PR will instead:

- Keep `getAlarm` at its pre-#155 signature (back-compat for current clients).
- Introduce a new `queryAlarms` query with a single `AlarmQueryCondition` input type carrying `layers`, `serviceIds`, `serviceInstanceIds`, `endpointIds`, `ruleNames`, `scope`, `keyword`, `tags`, `duration`, and `paging`.
- Re-introduce `AlarmMessage.layers: [String!]!` in that new PR alongside the `queryAlarms` schema, so the layer story ships in a single coherent change instead of accreting argument-by-argument on `getAlarm`.

The follow-up PR will land before the OAP backend implementation, so this revert leaves the schema clean for the new shape.

## Test plan

- [ ] Confirm `getAlarm` signature returns to its pre-#155 form
- [ ] Confirm `AlarmMessage` no longer has the `layers` field (it returns in the new PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)