### PR TITLE
alarm: add queryAlarms with Entity-based filter; deprecate getAlarm

### DIFF
--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -49,8 +49,60 @@ input AlarmTag {
     value: String
 }
 
+# Filter shape for `queryAlarms`. All fields outside `duration` and `paging`
+# are optional; within each list-typed field values are OR'd (set union),
+# across fields the predicates are AND'd.
+input AlarmQueryCondition {
+    duration: Duration!
+    paging: Pagination!
+
+    # Pin to specific entities. Each `Entity` (defined in metrics-v3.graphqls)
+    # resolves to its underlying serviceId / instanceId / endpointId /
+    # processId at query time; the alarm filter matches the alarm record's
+    # primary (id0) OR relation-destination (id1) column against the resolved
+    # IDs. For relation entities (set via `destServiceName` etc.) the source
+    # and dest IDs are both contributed, so the alarm is matched whether the
+    # entity appears as the source or the dest of the relation.
+    #
+    # Across the list values OR together. Entity's own `scope` field is
+    # auto-inferred from which name fields are populated, mirroring its MQE
+    # behavior.
+    entities: [Entity!]
+
+    # Filter on the underlying entity's layer. A service observed under
+    # multiple normal layers (e.g., GENERAL + K8S_SERVICE) matches when any
+    # one of them is in the list. See
+    # https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java
+    # for the canonical layer list.
+    layers: [String!]
+
+    # Filter by the alarm rule(s) that fired the alarm.
+    ruleNames: [String!]
+
+    # Phrase match on the alarm message text. Same semantics as
+    # `getAlarm.keyword`.
+    keyword: String
+
+    # Searchable-tag filter. Tag keys must be in the OAP backend's
+    # `searchableAlarmTags` config; otherwise the query returns no rows.
+    tags: [AlarmTag]
+}
+
 extend type Query {
+    # DEPRECATED in favor of `queryAlarms(condition)`. Kept for backward
+    # compatibility; the OAP backend routes both queries to the same DAO.
+    # `queryAlarms` adds entity (Entity-typed) / rule-name / layer filters
+    # and bundles every filter under a single input type so future additions
+    # land without a method-signature change.
     getAlarm(duration: Duration!, scope: Scope, keyword: String, paging: Pagination!, tags: [AlarmTag]): Alarms
+        @deprecated(reason: "Use queryAlarms(condition) instead. getAlarm only exposes scope + keyword + tags filters; queryAlarms additionally supports entities (Entity-typed, multi-select) / ruleNames / layers and uses a single input type for future extensibility.")
+
+    # Query alarm records with the comprehensive filter set. Combine entity
+    # (Entity-typed, multi-select), layer, rule-name, keyword, and tag filters
+    # in one request. Replaces `getAlarm` for any client that needs more than
+    # scope + keyword + tags.
+    queryAlarms(condition: AlarmQueryCondition!): Alarms
+
     # Read the list of searchable keys
     queryAlarmTagAutocompleteKeys(duration: Duration!):[String!]
     # Search the available value options of the given key.


### PR DESCRIPTION
## Summary

Lands the comprehensive alarm query API. Lands purely additive on top of #156 (the #155 revert) — the diff vs master contains **no edits to `AlarmMessage`**.

### New: `queryAlarms(condition: AlarmQueryCondition!): Alarms`

Bundles every filter the OAP alarm record can support under a single input type. Future filter additions land on the input type rather than the method signature.

\`\`\`graphql
input AlarmQueryCondition {
    duration: Duration!
    paging: Pagination!
    entities: [Entity!]
    layers: [String!]
    ruleNames: [String!]
    keyword: String
    tags: [AlarmTag]
}
\`\`\`

| Filter | Semantics |
|---|---|
| \`entities\` | Pin to specific entities. Reuses the existing \`Entity\` input from \`metrics-v3.graphqls\` — the same shape operators already use for MQE. Each Entity resolves to its underlying serviceId / instanceId / endpointId / processId at query time; the alarm filter matches the alarm record's primary (\`id0\`) OR relation-destination (\`id1\`) column against the resolved IDs. Across the list, values OR together. |
| \`layers\` | Multi-select layer filter on the underlying entity's stored layer column. |
| \`ruleNames\` | Filter by the alarm rule(s) that fired. |
| \`keyword\` | Phrase match on the alarm message (same as \`getAlarm.keyword\`). |
| \`tags\` | Searchable-tag filter (same as \`getAlarm.tags\`). |

### Why reuse \`Entity\` instead of separate ID arrays

- **Consistency** with the MQE filter shape operators already use across the protocol.
- **Relations** are natural — \`Entity\` already has \`destServiceName\`, \`destServiceInstanceName\`, \`destEndpointName\`, \`destProcessName\`.
- **Forward-compatible** — \`Process\` is already covered without a new field; future entity types land on \`Entity\` once, not in three places.
- **Operator-friendly** — operators know entities by name (from the UI), not by raw IDs.

### Deprecation: \`getAlarm\`

Marked \`@deprecated\` pointing at \`queryAlarms\`. The OAP backend routes both queries to the same DAO so existing clients calling \`getAlarm\` keep working. No removal planned.

### AlarmMessage stays untouched

This PR does **not** reintroduce a \`layers\` field on \`AlarmMessage\` — that would have un-done part of #156's revert. The layer filter on \`queryAlarms\` matches against the alarm record's stored layer column; clients that need to know which layer fired an alarm resolve it via the alarm's entity through the metadata query surface, same as for other entity attributes.

## PR stack

- **#156** — merged. Reverts #155.
- **#157 (this PR)** — purely additive on top of #156. Adds \`AlarmQueryCondition\`, \`queryAlarms\`, \`@deprecated\` marker on \`getAlarm\`. No \`AlarmMessage\` changes.

## Backward compatibility

- \`getAlarm\` continues to work for clients that don't switch.
- \`queryAlarms\` is additive.
- No response-shape changes (\`AlarmMessage\` is untouched).

## Companion changes

- OAP backend PR (\`apache/skywalking\`) — pins this submodule SHA after this PR merges, adds the new \`layer\` column to AlarmRecord, flips \`id0\`/\`id1\` from \`storageOnly\` to indexed (existing indices keep their old shape; new daily-rolled indices pick up the indexed columns), wires \`queryAlarms\` end to end across BanyanDB / ES / JDBC, and routes the deprecated \`getAlarm\` to the same DAO with empty entity / layer / ruleNames filters.

## Test plan

- [ ] OAP backend PR builds against the merged submodule
- [ ] e2e: \`queryAlarms(condition: { duration: ..., paging: ..., entities: [{ serviceName: \"X\", normal: true }] })\` returns alarms scoped to service X
- [ ] e2e: \`queryAlarms(condition: { ..., layers: [\"general\"] })\` filters by layer
- [ ] e2e: \`queryAlarms(condition: { ..., entities: [{ serviceName: \"A\", destServiceName: \"B\", normal: true, destNormal: true }] })\` covers service-relation alarms
- [ ] \`getAlarm(...)\` still works against the same DAO

🤖 Generated with [Claude Code](https://claude.com/claude-code)