### PR TITLE
alarm: clarify queryAlarms entity / layer semantics (doc only)

### DIFF
--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -58,20 +58,30 @@ input AlarmQueryCondition {
 
     # Pin to specific entities. Each `Entity` (defined in metrics-v3.graphqls)
     # resolves to its underlying serviceId / instanceId / endpointId /
-    # processId at query time; the alarm filter matches the alarm record's
-    # primary (id0) OR relation-destination (id1) column against the resolved
-    # IDs. For relation entities (set via `destServiceName` etc.) the source
-    # and dest IDs are both contributed, so the alarm is matched whether the
-    # entity appears as the source or the dest of the relation.
+    # processId at query time. Match shape depends on the entity scope:
     #
-    # Across the list values OR together. Entity's own `scope` field is
-    # auto-inferred from which name fields are populated, mirroring its MQE
-    # behavior.
+    # * Non-relation scopes (Service, ServiceInstance, Endpoint, Process):
+    #   match alarms whose `id0` OR `id1` equals the resolved entity ID.
+    #   Catches both alarms scoped exactly to the entity (id0=X) AND
+    #   relation alarms where the entity is the destination (id1=X).
+    #
+    # * Relation scopes (ServiceRelation, ServiceInstanceRelation,
+    #   EndpointRelation, ProcessRelation): EXACT match on the relation.
+    #   The constraint is `id0=resolvedSourceId AND id1=resolvedDestId`.
+    #   "Anything involving service A" queries should pass the non-relation
+    #   Entity {Service A} instead — the relation entity narrows to a
+    #   specific src→dest edge only.
+    #
+    # Across the list, per-entity constraints OR together. Entity's own
+    # `scope` field is auto-inferred from which name fields are populated,
+    # mirroring its MQE behavior.
     entities: [Entity!]
 
-    # Filter on the underlying entity's layer. A service observed under
-    # multiple normal layers (e.g., GENERAL + K8S_SERVICE) matches when any
-    # one of them is in the list. See
+    # Filter on the underlying entity's layer. An alarm record stores ONE
+    # layer per row (the alphabetically first layer of the alarmed entity at
+    # alarm-mint time), so a multi-layer service (e.g., [GENERAL,
+    # K8S_SERVICE]) is filed under its first layer and only that layer
+    # matches the filter. See
     # https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java
     # for the canonical layer list.
     layers: [String!]


### PR DESCRIPTION
## Summary

Doc-only fix to `alarm.graphqls` so the schema text matches how the OAP backend actually filters `queryAlarms`.

### What was inaccurate

- **Relation-entity match:** the previous doc said a relation entity (`{ServiceRelation, A→B}`) matches alarms 'whether the entity appears as the source or the dest of the relation' — implying `id0 OR id1`. The actual OAP backend uses **strict AND** (`id0=src AND id1=dest`), which makes the relation filter narrow to one specific edge. Operators who want 'any alarm involving service A' should pass the non-relation `{Service A}` entity (which expands to `id0=A OR id1=A`).
- **Layer match:** the previous doc said 'a service observed under multiple normal layers (e.g., GENERAL + K8S_SERVICE) matches when any one of them is in the list' — implying multi-value storage. The OAP alarm record actually stores ONE layer per row (the alphabetically first when the alarmed service has multiple layers), so a service in `[GENERAL, K8S_SERVICE]` is filed under `GENERAL` and only `layers: [\"GENERAL\"]` matches it.

### Why doc-only

Both issues are cosmetic — the GraphQL types, names, and arguments are unchanged. The fix replaces the misleading prose so:

- API consumers don't expect broader matches than they get.
- The single-layer-per-row reality is documented for operators that need it.

The narrowing for relations is a deliberate OAP design choice (per-entity AND/OR semantics in the storage DAO) and shouldn't be changed without breaking the relation-filter contract.

## No schema breakage

- No type renames, no argument changes, no field removals.
- Pre-#157 clients (which didn't use `queryAlarms` at all) unaffected.
- Post-#157 clients keep working; doc just tells them what to expect.

## Test plan

- [ ] No backend changes needed — text-only fix
- [ ] Confirm reading the doc top-to-bottom matches the apache/skywalking 11.0.0 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)