### PR TITLE
alarm: collapse queryAlarms layers filter to single layer

### DIFF
--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -69,12 +69,12 @@ input AlarmQueryCondition {
     # behavior.
     entities: [Entity!]
 
-    # Filter on the underlying entity's layer. A service observed under
-    # multiple normal layers (e.g., GENERAL + K8S_SERVICE) matches when any
-    # one of them is in the list. See
+    # Filter on the underlying entity's layer. An alarm record is persisted
+    # with a single layer (the first one in the entity's resolved layer
+    # list); this filter matches that single value exactly. See
     # https://github.com/apache/skywalking/blob/master/oap-server/server-core/src/main/java/org/apache/skywalking/oap/server/core/analysis/Layer.java
     # for the canonical layer list.
-    layers: [String!]
+    layer: String
 
     # Filter by the alarm rule(s) that fired the alarm.
     ruleNames: [String!]
@@ -95,7 +95,7 @@ extend type Query {
     # and bundles every filter under a single input type so future additions
     # land without a method-signature change.
     getAlarm(duration: Duration!, scope: Scope, keyword: String, paging: Pagination!, tags: [AlarmTag]): Alarms
-        @deprecated(reason: "Use queryAlarms(condition) instead. getAlarm only exposes scope + keyword + tags filters; queryAlarms additionally supports entities (Entity-typed, multi-select) / ruleNames / layers and uses a single input type for future extensibility.")
+        @deprecated(reason: "Use queryAlarms(condition) instead. getAlarm only exposes scope + keyword + tags filters; queryAlarms additionally supports entities (Entity-typed, multi-select) / ruleNames / layer and uses a single input type for future extensibility.")
 
     # Query alarm records with the comprehensive filter set. Combine entity
     # (Entity-typed, multi-select), layer, rule-name, keyword, and tag filters


### PR DESCRIPTION
## Summary

\`AlarmRecord\` in the OAP persists a **single** layer column (the first
entry of the entity's resolved layer list — relation scopes use a
source-first \`LinkedHashSet\` union; single-entity scopes use the
metadata-service list as-is). The current \`AlarmQueryCondition.layers:
[String!]\` filter is asymmetric with the persisted shape — a list-of-N
query against a single value can only ever match position 0 anyway.

Collapse the filter to a single \`layer: String\` so the wire shape
matches the storage shape. Also touches the \`getAlarm\` \`@deprecated\`
reason for consistency.

Tracks the OAP-side rollout in apache/skywalking#13877.

## Test plan
- [ ] swctl / GraphIQL: \`queryAlarms(condition: { layer: \"GENERAL\", ... })\` returns same row set as the old \`layers: [\"GENERAL\"]\`.
- [ ] swctl with no layer set still returns the unfiltered alarm list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)