### PR TITLE
alarm + ui: clarify alarm entity-filter semantics; drop menu API

### DIFF
--- a/alarm.graphqls
+++ b/alarm.graphqls
@@ -57,16 +57,21 @@ input AlarmQueryCondition {
     paging: Pagination!
 
     # Pin to specific entities. Each `Entity` (defined in metrics-v3.graphqls)
-    # resolves to its underlying serviceId / instanceId / endpointId /
-    # processId at query time; the alarm filter matches the alarm record's
-    # primary (id0) OR relation-destination (id1) column against the resolved
-    # IDs. For relation entities (set via `destServiceName` etc.) the source
-    # and dest IDs are both contributed, so the alarm is matched whether the
-    # entity appears as the source or the dest of the relation.
+    # resolves to one EntityIdConstraint at query time:
+    #   * Non-relation scopes (Service / ServiceInstance / Endpoint / Process)
+    #     match the alarm record's id0 OR id1 column against the resolved id
+    #     — a service appears in either column depending on which side of the
+    #     alarm rule fired, so we accept both.
+    #   * Relation scopes (`destServiceName` etc.) match exactly
+    #     `id0 = sourceId AND id1 = destId` — ordered, NOT "any side". A
+    #     ServiceRelation entity `{serviceName: A, destServiceName: B}` only
+    #     matches alarms keyed `(A, B)`. To find anything involving A, pass a
+    #     non-relation `{serviceName: A}` entity instead, which expands to
+    #     `id0 = A OR id1 = A`.
     #
-    # Across the list values OR together. Entity's own `scope` field is
-    # auto-inferred from which name fields are populated, mirroring its MQE
-    # behavior.
+    # Across the list, the per-entity constraints are OR'd together. Entity's
+    # own `scope` field is auto-inferred from which name fields are
+    # populated, mirroring its MQE behavior.
     entities: [Entity!]
 
     # Filter on the underlying entity's layer. An alarm record is persisted

--- a/ui-configuration.graphqls
+++ b/ui-configuration.graphqls
@@ -23,33 +23,11 @@ type DashboardConfiguration {
     configuration: String!
 }
 
-type MenuItem {
-    # Title name
-    title: String!
-    # Showing icon name
-    icon: String
-    # Linked layer name
-    layer: String!
-    # Activated menu should be listed on the menu,
-    # otherwise, it should stay in marketplace.
-    activate: Boolean!
-    # Sub menu items
-    subItems: [MenuItem!]!
-    # Description of the item
-    description: String
-    # The document link for the latest version of this feature.
-    documentLink: String
-    # The i18n key for the title and description of this feature display in the UI.
-    i18nKey: String
-}
-
 extend type Query {
     # Read an existing UI template according to given id.
     getTemplate(id: String!): DashboardConfiguration
     # Read all configuration templates。
     getAllTemplates: [DashboardConfiguration!]!
-    # Read all menu items
-    getMenuItems: [MenuItem!]!
 }
 
 # Used for add new template


### PR DESCRIPTION
## Summary

Two doc / cleanup items spotted during apache/skywalking#13877 review:

* **alarm.graphqls** — \`AlarmQueryCondition.entities\` text said
  relation entities match whether the entity appears as source or
  dest, but the OAP DAO has always implemented exact-ordered match
  (\`id0 = sourceId AND id1 = destId\`). Rewrite the entity comment
  to match the implemented semantics and point operators at the
  non-relation widening pattern. Non-relation matching
  (\`id0 OR id1\`) is unchanged and now documented explicitly.

* **ui-configuration.graphqls** — drop the menu surface
  (\`MenuItem\` type + \`getMenuItems\` query). Sidebar menu
  management is removed from OAP in apache/skywalking 11.0.0 in
  favor of Horizon UI client-side gating. **All template CRUD stays
  intact**: \`DashboardConfiguration\`, \`NewDashboardSetting\`,
  \`DashboardSetting\`, \`TemplateChangeStatus\`, \`getTemplate\`,
  \`getAllTemplates\`, \`addTemplate\`, \`changeTemplate\`,
  \`disableTemplate\` — operators still need them.

Supersedes #160 (which over-deleted the whole ui-configuration file).

## Test plan
- [ ] OAP boot: GraphQL schema validates without \`MenuItem\` /
      \`getMenuItems\`; the apache/skywalking-side resolver no longer
      references the menu service.
- [ ] Template CRUD still callable via GraphIQL.
- [ ] Doc-only change for alarm entity filter — no resolver behavior
      changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)