### PR TITLE
genai: typed condition fields and source-aware span addressing

### DIFF
--- a/gen-ai-evaluation-record.graphqls
+++ b/gen-ai-evaluation-record.graphqls
@@ -21,28 +21,59 @@ type GenAIEvaluationRecords {
     debuggingTrace: DebuggingTrace
 }
 
+# The addressing scheme of the span an evaluation was produced from.
+enum GenAITraceRefType {
+    # SkyWalking native: trace + segment + segment-local span index.
+    SKYWALKING_NATIVE
+    # OTLP / Zipkin: trace + globally unique hex span id. No segment concept.
+    OTLP
+}
+
+# Points at the span an evaluation was produced from, in whichever addressing scheme
+# its source used. GenAI evaluation accepts SkyWalking native, OTLP and Zipkin traces,
+# and a single span-id type cannot describe all of them.
+type GenAITraceRef {
+    type: GenAITraceRefType!
+    traceId: String!
+    # SKYWALKING_NATIVE only. The segment carrying the span.
+    segmentId: String
+    # SKYWALKING_NATIVE only. Segment-local index (0, 1, 2 ...), NOT an identifier.
+    # Unique only in combination with segmentId.
+    spanIndex: Int
+    # OTLP / Zipkin only. 16 lowercase hex characters, globally unique within the trace.
+    spanId: String
+}
+
 type GenAIEvaluationRecord {
-    traceId: String
+    traceRef: GenAITraceRef!
+
+    # The application service that issued the GenAI call. SERVICE scope, a normal
+    # (agent-detected) service - its layer is whatever the agent reports.
     serviceId: String
     serviceName: String
+    # The GenAI provider. SERVICE scope, Layer.VIRTUAL_GENAI (conjectured).
+    # The same entity as GenAIProviderAccess.
     providerId: String
     providerName: String
+    # The model. SERVICE_INSTANCE scope under the provider service, Layer.VIRTUAL_GENAI.
+    # The same entity as GenAIModelAccess.
     modelId: String
     modelName: String
+
     operationName: String
-    # The value type determines which field contains the evaluation value.
-    # SCORE and BOOLEAN use scoreValue; STRING and JSON use value.
-    valueType: GenAIEvaluationValueType
-    # Numeric value stored in evaNumberValue using the 1,000,000 scale. It is populated for SCORE and BOOLEAN.
-    scoreValue: Long
-    # String or JSON value stored in evalStringValue. It is populated for STRING and JSON.
-    value: String
-    segmentId: String
-    spanId: String
-    spanType: String
     taskName: String
-    evaluationLevel: String
+    # Determines which of the three value fields below is populated.
+    valueType: GenAIEvaluationValueType!
+    # Populated when valueType = SCORE. Carried on the 1,000,000 ppm scale as stored;
+    # divide by 1,000,000 to display the original 0.0-1.0 score.
+    scoreValue: Long
+    # Populated when valueType = BOOLEAN.
+    booleanValue: Boolean
+    # Populated when valueType = STRING or JSON. Parse according to valueType.
+    stringValue: String
+    # The judge's explanation. Populated for every task, whatever the value type.
     reason: String
+    evaluationLevel: String
     judgeModel: String
     evaluationTime: Long
 }
@@ -59,30 +90,36 @@ enum GenAIEvaluationValueType {
     JSON
 }
 
-input GenAIEvaluationRecordTag {
-    key: String!
-    value: String
-}
-
 input GenAIEvaluationRecordQueryCondition {
-    serviceId: ID
+    # The GenAI provider, a VIRTUAL_GENAI service.
     providerId: ID
+    # The model, a VIRTUAL_GENAI service instance under the provider.
     modelId: ID
-    # Filter value_type first when selecting a specific evaluation kind.
+    # The application service that issued the GenAI call.
+    serviceId: ID
+
+    taskName: String
+    # Filter valueType first when selecting a specific evaluation kind.
     valueType: GenAIEvaluationValueType
-    # Bounds for evaNumberValue, used only with the SCORE value type. Values use the 1,000,000 scale.
+    # Bounds for scoreValue on the 1,000,000 ppm scale, as stored.
+    # Only meaningful when valueType = SCORE.
     minScore: Long
     maxScore: Long
-    # Boolean value to match. This is only used when valueType is BOOLEAN.
+    # Boolean value to match. Only meaningful when valueType = BOOLEAN.
     booleanValue: Boolean
-    sortBy: GenAIEvaluationRecordSortBy
-    taskName: String
     evaluationLevel: String
     judgeModel: String
-    relatedTrace: TraceScopeCondition
+
+    # [Required] queryDuration is required in most queries, the only exception
+    # is when relatedTrace is used.
     queryDuration: Duration
+    # Scopes to a SkyWalking native trace, segment and span. OTLP / Zipkin evaluations
+    # are scoped by traceId only - their span ids are not addressable through this
+    # native-oriented condition.
+    relatedTrace: TraceScopeCondition
+
     paging: Pagination!
-    tags: [GenAIEvaluationRecordTag!]
+    sortBy: GenAIEvaluationRecordSortBy
     queryOrder: Order
 }
 


### PR DESCRIPTION
Follow-up to #163, from reviewing the OAP implementation in apache/skywalking#13943. No OAP submodule pointer references #163 yet, so these changes carry no client impact.

### 1. Remove `tags` and `GenAIEvaluationRecordTag`

A `tags` condition exists so callers can filter on key-values the protocol *cannot enumerate*. This record has none — it persists no user-supplied attribute.

The asymmetry is the tell: `Log` returns `tags: [KeyValue!]` and `LogQueryCondition` filters them, whereas `GenAIEvaluationRecord` has no `tags` field at all — so the condition filtered something the API never returns.

In the OAP implementation the accepted key set turns out to be the record's own column names: 11 of 15 are already typed fields on the same condition, and the remaining 4 (`operation_name`, `span_type`, `evalStringValue`, `reason`) are fixed columns of a record the protocol fully defines. Nothing in the set is custom.

### 2. Address the span by its source scheme

GenAI evaluation accepts SkyWalking native, OTLP and Zipkin traces. Native span ids are a segment-local `int` index; OTLP and Zipkin ids are 16 hex characters. `spanId: String` cannot describe both honestly — and in the implementation it is parsed into an `int`, which throws for every OTLP/Zipkin span.

`GenAITraceRef` makes the scheme explicit, and `spanIndex` is named for what it is: an index, not an identifier, unique only with `segmentId`.

This stays **GenAI-scoped**. `spanId: Int` in `trace.graphqls`, `profile.graphqls` and `TraceScopeCondition` is correctly scoped to native-trace addressing and does not change.

### 3. Split the value slots

`scoreValue` (SCORE) / `booleanValue` (BOOLEAN) / `stringValue` (STRING, JSON), so `valueType` genuinely discriminates. BOOLEAN previously shared `scoreValue` as `0` / `1000000`, which meant `minScore`/`maxScore` silently spanned both types. `value` → `stringValue` for parallel naming; `reason` stays separate because it is orthogonal and populated for every task.

### 4. Drop `spanType`

`SpanEvaluationType` has exactly one value, `LLM_CALL` — nothing to query and nothing to display. Reintroduce as an enum if a second span kind appears.

### 5. Document entity scope and layer

Provider is a **service** and model is its **instance**, both `Layer.VIRTUAL_GENAI`, while `serviceId` is a normal agent-detected service. Stating this on the fields makes an entity-id mistake visible at review time.

---

Scores remain `Long` on the 1,000,000 ppm scale, unchanged — SkyWalking does not carry `Float`/`Double` in stored or transported values; the convention is `Long` with the code controlling precision.

### OAP-side changes this requires

- `getScoreValue()` returns the stored `Long` rather than dividing into a `Double`
- the Java condition takes `Long` for `minScore`/`maxScore`; the DAOs stop re-scaling an already-scaled input
- `booleanValue` wired through the condition and all three DAOs
- `spanId` becomes a `String` column plus a `ref_type` column; the `Integer.parseInt` is removed
- `value_type` loses `storageOnly` so it is filterable on Elasticsearch
- `QUERYABLE_TAG_KEYS` deleted from the ES and JDBC DAOs, and the BanyanDB tag loop with it
- the writer must always set `valueType`, now non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)
