### PR TITLE
ai-agent: serve the conversation view over a streamed HTTP route, not GraphQL

### DIFF
--- a/ai-agent-conversation.graphqls
+++ b/ai-agent-conversation.graphqls
@@ -26,9 +26,22 @@
 # Session Data (`.sd`, the records of one session as collected) and Session Flow (`.sf`, an append-only
 # chain of rounds the assembler derived from them). The OAP stores every file verbatim.
 #
-# A conversation is read once, whole. `getConversationView` folds the rounds, resolves every reference
-# into the landed records and returns one `asz.view` file: everything a viewer renders, evidence included.
-# The UI makes that one call per conversation and no other.
+# A conversation is read once, whole, and not through GraphQL. The document is as large as the
+# conversation, tens of megabytes for a long one, so it is served by its own route on the same HTTP server
+# as `/graphql`, streamed as it is rendered and compressed when the client allows:
+#
+#   GET /ai-agent/conversations/{conversation}/v1/view?service={serviceName}[&instance={instanceName}]
+#
+# `service` is the service name, or `serviceId` the id; `instance`, optional, is the sender's instance name.
+# `v1` is the document version: the body is one `asz.view` 1.0 document, everything a viewer renders,
+# evidence included, as `asz conversation` prints it. Its first two keys are `format` and `version`, and the
+# UI switches its renderer on them. The body is JSON, or YAML on `Accept: application/yaml`; `Content-Encoding`
+# follows `Accept-Encoding`. Verification is content, not an error: a missing round or a failed digest is
+# written into the document's `summary.state` and `summary.problems`, and the rest holds whatever could still
+# be folded. The route answers 400 when no service is named, 404 when the service stores no round of the
+# conversation, 500 on a storage failure, each with a JSON body `{"errorReason": "..."}`. It runs under its
+# own timeout, the OAP's `viewRequestTimeout`, in place of the server's default. The UI makes that one call
+# per conversation and no other.
 
 # One row per conversation on the list page. Every value comes from the newest round's attributes;
 # nothing is decoded to build the list.
@@ -68,24 +81,8 @@ input ConversationListCondition {
     limit: Int
 }
 
-# The whole conversation, once: one `asz.view` file, as `asz view` writes it locally.
-# The file is YAML. Its first two keys are `format` and `version`; the UI switches its renderer on them.
-# Verification is content, not an error: a missing round or a failed digest is written into the file's
-# `summary.state` and `summary.problems`, and the rest of the file holds whatever could still be folded.
-type ConversationView {
-    # When this field is not empty, frontend should display it in UI
-    errorReason: String
-    # `asz.view`
-    format: String!
-    # `1.0`
-    version: String!
-    conversation: ID!
-    # The `.view` file, verbatim.
-    yaml: String!
-    # For OAP internal query debugging
-    debuggingTrace: DebuggingTrace
-}
-
+# One conversation. The conversation is enough: its rounds name its sessions and give the time range, and
+# those give the files.
 input ConversationCondition {
     service: ServiceCondition!
     conversation: ID!
@@ -133,9 +130,6 @@ type ConversationRawFiles {
 extend type Query {
     # The conversations of a service active in the duration, newest first.
     listConversations(condition: ConversationListCondition!, duration: Duration!, debug: Boolean): ConversationList
-    # One conversation, whole. The conversation is enough: its rounds name its sessions and give the time
-    # range, and those give the files.
-    getConversationView(condition: ConversationCondition!, debug: Boolean): ConversationView
     # Every file of a conversation, as stored. Select `body` to export them.
     # `files`, optional: only these files, by id. A `.sd` id names its session and its seq, so the read is
     # exact and indexed; a round id is matched among the conversation's rounds. Without it, every file.


### PR DESCRIPTION
Follow-up to #166.

The `asz.view` document is as large as the conversation it describes: a session of 136 MB of landed files renders to a 70 MB document. Measured on the OAP, building it takes about six seconds of storage reads plus five of fold and render, so as a GraphQL query it fails on the HTTP server's ten second default timeout, and even when it fits, the whole document has to exist as one JSON string on both sides.

The OAP now serves the document from its own route on the same HTTP server as `/graphql`, streamed as it is rendered, compressed when the client allows, under its own timeout:

```
GET /ai-agent/conversations/{conversation}/v1/view?service={serviceName}[&instance={instanceName}]
```

`v1` is the document version. The body is JSON, or YAML on `Accept: application/yaml`; 400 without a service, 404 when no round of the conversation is stored, 500 on a storage failure, each with `{"errorReason": "..."}`.

This PR removes the `getConversationView` query and the `ConversationView` type, and documents the route in the file header beside the two queries that remain, `listConversations` and `getConversationRawFiles`.

OAP side: apache/skywalking, branch `feat/ai-agent-conversation`, unreleased (11.1.0), so nothing shipped depends on the removed query.