### PR TITLE
ai-agent: filter the conversation list by conversation id and by title

### DIFF
--- a/ai-agent-conversation.graphqls
+++ b/ai-agent-conversation.graphqls
@@ -78,6 +78,11 @@ input ConversationListCondition {
     service: ServiceCondition!
     # Optional. Only the conversations pushed by this sender.
     instance: InstanceCondition
+    # Optional. Only this conversation, by id: a storage lookup, so the round budget is spent on it alone.
+    conversation: ID
+    # Optional. Only the conversations whose title contains this text, case-insensitively. The title is the newest
+    # round's, so the match runs after folding and cannot widen the rounds read.
+    title: String
     # The rounds are read newest first, at most this many, then folded to one row per conversation.
     # Default 1000. A page therefore holds at most this many rows.
     limit: Int


### PR DESCRIPTION
Follow-up to #166. Two optional fields on `ConversationListCondition`, consumed by apache/skywalking#14057:

- `conversation: ID` narrows the read to one conversation. It is a storage lookup, so the round budget (`limit`) is spent on that conversation alone.
- `title: String` keeps only the rows whose title contains the text, case-insensitively. The title is the newest round's, so the match runs after folding and cannot widen the rounds read.

Input-only change; no type or query changes.