### PR TITLE
Describe the unbounded default time range of queryTrace and TraceList.retrievedTimeRange

### DIFF
--- a/trace-v2.graphqls
+++ b/trace-v2.graphqls
@@ -17,7 +17,8 @@
 type TraceList {
     traces: [TraceV2!]!
     # The time range of the traces actually retrieved.
-    # If the queryDuration is not given, the time range is the timestamp(ms) from now - 1day to now.
+    # If the queryDuration is not given, the time range is the timestamp(ms) from 0 to now,
+    # i.e. everything the hot/warm stages retain.
     retrievedTimeRange: RetrievedTimeRange!
     # For OAP internal query debugging
     debuggingTrace: DebuggingTrace

--- a/trace.graphqls
+++ b/trace.graphqls
@@ -197,7 +197,7 @@ extend type Query {
     queryBasicTraces(condition: TraceQueryCondition, debug: Boolean): TraceBrief
     queryBasicTracesByName(condition: TraceQueryConditionByName, debug: Boolean): TraceBrief
     # Read the specific trace ID with given trace ID
-    # duration is optional, and only for BanyanDB. If not provided, means search in the last 1 day.
+    # duration is optional, and only for BanyanDB. If not provided, means search in everything the hot/warm stages retain.
     queryTrace(traceId: ID!, duration: Duration, debug: Boolean): Trace
     # Read the list of searchable keys
     queryTraceTagAutocompleteKeys(duration: Duration!):[String!]


### PR DESCRIPTION
Two schema comments still describe the one-day fallback that OAP's BanyanDB storage applied to queries without a duration:

- `trace.graphqls`, `queryTrace`: "If not provided, means search in the last 1 day."
- `trace-v2.graphqls`, `TraceList.retrievedTimeRange`: "from now - 1day to now."

The OAP side is dropping that fallback. A query without a duration is bound to the largest time range instead, so it covers everything the group's hot/warm stages still retain, and `retrievedTimeRange` reports `0` to now in that case. This PR updates the two comments to match; the schema itself is unchanged.

The corresponding OAP change will bump this submodule once merged.
