### PR TITLE
TraceQueryCondition must contain either queryDuration or traceId

### DIFF
--- a/trace-v2.graphqls
+++ b/trace-v2.graphqls
@@ -16,9 +16,8 @@
 
 type TraceList {
     traces: [TraceV2!]!
-    # The time range of the traces actually retrieved.
-    # If the queryDuration is not given, the time range is the timestamp(ms) from 0 to now,
-    # i.e. everything the hot/warm stages retain.
+    # The time range of the traces actually retrieved, in timestamp(ms): the queryDuration of the condition,
+    # which queryTraces requires.
     retrievedTimeRange: RetrievedTimeRange!
     # For OAP internal query debugging
     debuggingTrace: DebuggingTrace

--- a/trace-v2.graphqls
+++ b/trace-v2.graphqls
@@ -17,7 +17,7 @@
 type TraceList {
     traces: [TraceV2!]!
     # The time range of the traces actually retrieved, in timestamp(ms): the queryDuration of the condition,
-    # which queryTraces requires.
+    # or 0 to now for a traceId lookup without queryDuration.
     retrievedTimeRange: RetrievedTimeRange!
     # For OAP internal query debugging
     debuggingTrace: DebuggingTrace

--- a/trace.graphqls
+++ b/trace.graphqls
@@ -32,6 +32,7 @@ type BasicTrace {
 }
 
 # Represent the conditions used for query TraceBrief
+# The condition must contain either queryDuration or traceId.
 input TraceQueryCondition {
     # The value of 0 means all services.
     serviceId: ID


### PR DESCRIPTION
Follow-up to #170. OAP's `queryTraces` now rejects a `TraceQueryCondition` that has neither `queryDuration` nor `traceId`; a `traceId` lookup is the only trace list query allowed without a time range, and BanyanDB then searches everything its hot/warm stages retain.

- `TraceQueryCondition` documents the either-or rule.
- `TraceList.retrievedTimeRange` is the condition's `queryDuration`, or 0 to now for a `traceId` lookup without one, replacing the unbounded-default wording from #170.

Comment-only change. The OAP side is apache/skywalking#14059, which will bump this submodule once merged.
